### PR TITLE
Adds preventDefault and stopPropagation methods

### DIFF
--- a/lib/js/src/tea_html.js
+++ b/lib/js/src/tea_html.js
@@ -332,8 +332,18 @@ function checked(b) {
               "checked",
               "checked"
             ]);
+  } else {
+    return /* NoProp */0;
   }
-  else {
+}
+
+function draggable(b) {
+  if (b) {
+    return /* RawProp */Block.__(0, [
+              "draggable",
+              "draggable"
+            ]);
+  } else {
     return /* NoProp */0;
   }
 }

--- a/src/tea_html.ml
+++ b/src/tea_html.ml
@@ -129,6 +129,8 @@ let name str = prop "name" str
 
 let checked b = if b then prop "checked" "checked" else noProp
 
+let draggable b = if b then prop "draggable" "draggable" else noProp
+
 let for' str = prop "htmlFor" str
 
 let hidden b = if b then prop "hidden" "hidden" else noProp

--- a/src/web_event.ml
+++ b/src/web_event.ml
@@ -5,6 +5,8 @@
 type 'node t = <
   target : 'node Js.undefined [@bs.get];
   keyCode : int [@bs.get];
+  preventDefault : unit -> unit [@bs.meth];
+  stopPropagation : unit -> unit [@bs.meth];
 > Js.t
 
 type 'node cb = 'node t -> unit [@bs]


### PR DESCRIPTION
This adds type definitions for the `preventDefault` and `stopPropagation` methods on JS events.

Example use (in Reason):

```reason
    let cb itemId ev => {
        ev##stopPropagation ();
        ev##preventDefault ();
        Some (ItemMouseDown itemId)
    };

    li [ onCB "mousedown" "" (cb itemId) ] [ text "List item" ]
```