### PR TITLE
Adds preventDefault and stopPropagation methods

### DIFF
--- a/src/web_event.ml
+++ b/src/web_event.ml
@@ -5,6 +5,8 @@
 type 'node t = <
   target : 'node Js.undefined [@bs.get];
   keyCode : int [@bs.get];
+  preventDefault : unit -> unit [@bs.meth];
+  stopPropagation : unit -> unit [@bs.meth];
 > Js.t
 
 type 'node cb = 'node t -> unit [@bs]


### PR DESCRIPTION
This adds type definitions for the `preventDefault` and `stopPropagation` methods on JS events.

Example use (in Reason):

```reason
    let cb itemId ev => {
        ev##stopPropagation ();
        ev##preventDefault ();
        Some (ItemMouseDown itemId)
    };

    li [ onCB "mousedown" "" (cb itemId) ] [ text "List item" ]
```