### PR TITLE
Add rel attribute

### DIFF
--- a/src/tea_html.ml
+++ b/src/tea_html.ml
@@ -230,4 +230,5 @@ module Attributes = struct
 
   let acceptCharset c = attribute "" "accept-charset" c
 
+  let rel value = attribute "" "rel" value
 end


### PR DESCRIPTION
According to the Elm docs:
Specifies the relationship of the target object to the link object.
For `a`, `area`, `link`.

Was missing.