### PR TITLE
Add a test demonstrating bug related to `noProp`

### DIFF
--- a/test/test_client_attribute_removal.ml
+++ b/test/test_client_attribute_removal.ml
@@ -18,19 +18,20 @@ let render_selected = function
       ; div [onClick Delete] [text "delete selection"]]
   | None -> div [] [text "Nothing selected"]
 
-let lang l is_selected =
-  let baseProps = [onClick (Select l); style "color" "blue"] in
-  let props = if is_selected == true then (style "border" "1px solid black")::baseProps else baseProps
-  in
-  li props [text l]
-
 (* let lang l is_selected =
+ *   let baseProps = [onClick (Select l); style "color" "blue"] in
+ *   let props = if is_selected == true then (style "border" "1px solid black")::baseProps else baseProps
+ *   in
+ *   li props [text l] *)
+
+let lang l is_selected =
   li
     [ onClick (Select l)
     ; style "color" "blue"
     ; if is_selected then style "border" "1px solid black" else noProp
+    ; if is_selected then Vdom.prop "lang" l else noProp
     ]
-    [ text l ] *)
+    [ text l ]
 
 let render_languages selected languages =
   let is_selected selected language =


### PR DESCRIPTION
When a vdom property is given a non-trivial value and is then changed to
`noProp`, the attribute ends up having as value the string "undefined". For the
example added in this commit, the element might end up looking like:

```html
<li lang="undefined" style="color: blue;">Ocaml</li>
```