### PR TITLE
Make Tea.Random.list tail recursive to prevent stack overflows.

### DIFF
--- a/src/tea_random.ml
+++ b/src/tea_random.ml
@@ -30,8 +30,8 @@ let float min max =
 
 
 let list count (Generator genCmd) =
-  let rec buildList state i = if i > 0 then (genCmd state)::(buildList state (i-1)) else [] in
-  Generator (fun state -> buildList state count)
+  let rec buildList state i acc = if i > 0 then buildList state (i - 1) (genCmd state :: acc) else acc in
+  Generator (fun state -> buildList state count [])
 
 
 let map func (Generator genCmd) =


### PR DESCRIPTION
Hi @OvermindDL1!

I recently stumbled upon this wonderful project and was trying to implement the js-framework-benchmarks app and found a bug in `Tea.Random`: the `list` function is not TCO'd by BuckleScript which results in generating 10k values to overflow the stack. I've modified the function to be tail recursive.

Here's the compiled output before:

```
function list(count, param) {
  var genCmd = param[0];
  var buildList = function (state, i) {
    if (i > 0) {
      return /* :: */[
              Curry._1(genCmd, state),
              buildList(state, i - 1 | 0)
            ];
    } else {
      return /* [] */0;
    }
  };
  return /* Generator */[(function (state) {
              return buildList(state, count);
            })];
}
```

and after:

```
function list(count, param) {
  var genCmd = param[0];
  return /* Generator */[(function (state) {
              var state$1 = state;
              var _i = count;
              var _acc = /* [] */0;
              while(true) {
                var acc = _acc;
                var i = _i;
                if (i > 0) {
                  _acc = /* :: */[
                    Curry._1(genCmd, state$1),
                    acc
                  ];
                  _i = i - 1 | 0;
                  continue ;

                } else {
                  return acc;
                }
              };
            })];
}
```

I'm very new to OCaml so let me know if there's a better way to do this.