### PR TITLE
lift restrictions on the version of bs-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
     "url": "https://github.com/overminddl1/bucklescript-tea/issues"
   },
   "homepage": "https://github.com/overminddl1/bucklescript-tea#readme",
-  "peerDependencies": {
-    "bs-platform": "^3.0.0"
-  },
   "devDependencies": {
     "browserify": "^14.0.0",
     "bs-platform": "^3.0.0",


### PR DESCRIPTION
the current major version is 4.0(see https://github.com/BuckleScript/bucklescript/pull/2960)