### PR TITLE
Improve model format shown in debug panel.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,3 +32,4 @@ In alphabetical order in their requisite sections.
 
 - @canadaduane (Duane Johnson): Creating the auto-conversion between the OCaml and Reason files, tremendously useful so people can see how each work!
 
+- @dboris (Boris Dobroslavov): Improving model history debug format.


### PR DESCRIPTION
If project using bucklescript-tea is built with `-bs-g` flag added to bsconfig.json, model history values will be printed with better formatting in debug panel. See https://bucklescript.github.io/docs/en/better-data-structures-printing-debug-mode