### PR TITLE
Change Tea.Random.(int|float) to be inclusive of the max range and to…

### DIFF
--- a/src-ocaml/tea_random.ml
+++ b/src-ocaml/tea_random.ml
@@ -28,7 +28,7 @@ let int min max =
 
 let float min max =
   let (min, max) = if min < max then (min, max) else (max, min) in
-  Generator (fun state -> min +. Random.State.float state (max -. min +. 1.0))
+  Generator (fun state -> min +. Random.State.float state (max -. min))
 
 
 let list count (Generator genCmd) =

--- a/src-ocaml/tea_random.ml
+++ b/src-ocaml/tea_random.ml
@@ -27,7 +27,6 @@ let int min max =
 
 
 let float min max =
-  let (min, max) = if min < max then (min, max) else (max, min) in
   Generator (fun state -> min +. Random.State.float state (max -. min))
 
 

--- a/src-ocaml/tea_random.ml
+++ b/src-ocaml/tea_random.ml
@@ -22,11 +22,13 @@ let bool =
 
 
 let int min max =
-  Generator (fun state -> min + Random.State.int state (max - min))
+  let (min, max) = if min < max then (min, max) else (max, min) in
+  Generator (fun state -> min + Random.State.int state (max - min + 1))
 
 
 let float min max =
-  Generator (fun state -> min +. Random.State.float state (max -. min))
+  let (min, max) = if min < max then (min, max) else (max, min) in
+  Generator (fun state -> min +. Random.State.float state (max -. min +. 1.0))
 
 
 let list count (Generator genCmd) =

--- a/src-reason/tea_random.re
+++ b/src-reason/tea_random.re
@@ -19,7 +19,7 @@ let int = (min, max) =>
 
 let float = (min, max) =>
   let (min, max) = (min < max) ? (min, max) : (max, min);
-  Generator(state => min +. Random.State.float(state, max -. min +. 1.0));
+  Generator(state => min +. Random.State.float(state, max -. min));
 
 let list = (count, Generator(genCmd)) => {
   let rec buildList = (state, i, acc) =>

--- a/src-reason/tea_random.re
+++ b/src-reason/tea_random.re
@@ -14,10 +14,12 @@ type t('typ) =
 let bool = Generator(state => Random.State.bool(state));
 
 let int = (min, max) =>
-  Generator(state => min + Random.State.int(state, max - min));
+  let (min, max) = (min < max) ? (min, max) : (max, min);
+  Generator(state => min + Random.State.int(state, max - min + 1));
 
 let float = (min, max) =>
-  Generator(state => min +. Random.State.float(state, max -. min));
+  let (min, max) = (min < max) ? (min, max) : (max, min);
+  Generator(state => min +. Random.State.float(state, max -. min +. 1.0));
 
 let list = (count, Generator(genCmd)) => {
   let rec buildList = (state, i, acc) =>

--- a/src-reason/tea_random.re
+++ b/src-reason/tea_random.re
@@ -18,7 +18,6 @@ let int = (min, max) =>
   Generator(state => min + Random.State.int(state, max - min + 1));
 
 let float = (min, max) =>
-  let (min, max) = (min < max) ? (min, max) : (max, min);
   Generator(state => min +. Random.State.float(state, max -. min));
 
 let list = (count, Generator(genCmd)) => {


### PR DESCRIPTION
… handle descending ranges

Right now the Random feature only generates numbers from min (inclusive) to max (exclusive), because of the way OCaml's standard library Random works.  I just add (+1) to make sure the max was also inclusive.

Also, I took a quick look at the Elm source code, don't really understand it, but it looks like it also handles descending ranges (where the max is greater than the min), so I included that as well.

Note: This is my first time contributing to any open source project (so, let me know if this is OK).