### PR TITLE
Use valid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "OCaml"
   ],
   "author": "OvermindDL1",
-  "license": "LGPLv3",
+  "license": "LGPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/overminddl1/bucklescript-tea/issues"
   },


### PR DESCRIPTION
This fixes a warning from yarn: `warning package.json: License should be a valid
SPDX license expression`

I got the license name from https://spdx.org/licenses/. I chose 3.0-or-later as it matches what's written in the LICENSE file.