### PR TITLE
Require key use in Html.onWithOptions and Time.every

### DIFF
--- a/src-ocaml/tea_html.ml
+++ b/src-ocaml/tea_html.ml
@@ -339,8 +339,8 @@ let defaultOptions = {
   preventDefault = false;
 }
 
-let onWithOptions eventName options decoder =
-  onCB eventName "" (fun event ->
+let onWithOptions ~(key:string) eventName (options: Tea_html.options) decoder =
+  onCB eventName key (fun event ->
     if options.stopPropagation then event##stopPropagation () |> ignore;
     if options.preventDefault then event##preventDefault () |> ignore;
     event

--- a/src-ocaml/tea_time.ml
+++ b/src-ocaml/tea_time.ml
@@ -11,9 +11,8 @@ type 'msg myCmd =
   | Delay of t * (unit -> 'msg) *)
 
 
-let every interval tagger =
+let every ~key interval tagger =
   let open Vdom in
-  let key = string_of_float interval in
   let enableCall callbacks =
     let id = (Web.Window.setInterval (fun () -> callbacks.enqueue (tagger (Web.Date.now ())) ) interval) in
     (* let () = Js.log ("Time.every", "enable", interval, tagger, callbacks) in *)

--- a/src-reason/tea_html.re
+++ b/src-reason/tea_html.re
@@ -4,7 +4,9 @@ module Cmds = Tea_html_cmds;
 
 /* let map lift vdom =
  */
+
 /* Nodes */
+
 let noNode = noNode;
 
 let text = str => text(str);
@@ -15,7 +17,9 @@ let node = (~namespace="", tagName, ~key="", ~unique="", props, nodes) =>
   fullnode(namespace, tagName, key, unique, props, nodes);
 
 /* let embedProgram main = custom */
+
 /* HTML Elements */
+
 let br = props => fullnode("", "br", "br", "br", props, []);
 
 let br' = (~key="", ~unique="", props, nodes) =>
@@ -298,6 +302,7 @@ let menu = (~key="", ~unique="", props, nodes) =>
   fullnode("", "menu", key, unique, props, nodes);
 
 /* Properties */
+
 let noProp = Vdom.noProp;
 
 let id = str => prop("id", str);
@@ -361,6 +366,7 @@ let action = a => prop("action", a);
 let method' = m => prop("method", m);
 
 /* Events */
+
 let onCB = (eventName, key, cb) => onCB(eventName, key, cb);
 
 let onMsg = (eventName, msg) => onMsg(eventName, msg);
@@ -434,10 +440,11 @@ type options = {
 
 let defaultOptions = {stopPropagation: false, preventDefault: false};
 
-let onWithOptions = (eventName, options, decoder) =>
+let onWithOptions =
+    (~key: string, eventName, options: Tea_html.options, decoder) =>
   onCB(
     eventName,
-    "",
+    key,
     event => {
       if (options.stopPropagation) {
         event##stopPropagation() |> ignore;
@@ -464,20 +471,26 @@ let keyCode = Tea_json.Decoder.field("keyCode", Tea_json.Decoder.int);
 
 module Attributes = {
   let max = value => attribute("", "max", value);
+
   let min = value => attribute("", "min", value);
+
   let step = value => attribute("", "step", value);
+
   let disabled = b =>
     if (b) {
       attribute("", "disabled", "true");
     } else {
       noProp;
     };
+
   let selected = b =>
     if (b) {
       attribute("", "selected", "true");
     } else {
       noProp;
     };
+
   let acceptCharset = c => attribute("", "accept-charset", c);
+
   let rel = value => attribute("", "rel", value);
 };

--- a/src-reason/tea_time.re
+++ b/src-reason/tea_time.re
@@ -6,9 +6,9 @@ type t = float;
 
    type 'msg myCmd =
      | Delay of t * (unit -> 'msg) */
-let every = (interval, tagger) => {
+
+let every = (~key, interval, tagger) => {
   open Vdom;
-  let key = string_of_float(interval);
   let enableCall = callbacks => {
     let id =
       Web.Window.setInterval(
@@ -31,6 +31,7 @@ let delay = (msTime, msg) =>
   });
 
 /* Generic Helpers */
+
 let millisecond = 1.0;
 
 let second = 1000.0 *. millisecond;


### PR DESCRIPTION
In https://github.com/OvermindDL1/bucklescript-tea/issues/97, you mention that would take changes to make key an optional parameter.

This makes the key mandatory in Html.onWithOptions and Time.every. The reason I went with making them requires -- though it is an API change -- is that I believe these are footguns and it doesn't seem possible to have reliable behaviour while not passing a key here.

If you truly believe they should not be required due to API issues, I can resubmit with that change, but I do feel this is the correct solution :)