### PR TITLE
Add ~key to Tea_html.on, fix onWithOptions API

### DIFF
--- a/src-ocaml/tea_html.ml
+++ b/src-ocaml/tea_html.ml
@@ -339,7 +339,7 @@ let defaultOptions = {
   preventDefault = false;
 }
 
-let onWithOptions ~(key:string) eventName (options: Tea_html.options) decoder =
+let onWithOptions ~(key:string) eventName (options: options) decoder =
   onCB eventName key (fun event ->
     if options.stopPropagation then event##stopPropagation () |> ignore;
     if options.preventDefault then event##preventDefault () |> ignore;
@@ -348,7 +348,7 @@ let onWithOptions ~(key:string) eventName (options: Tea_html.options) decoder =
     |> Tea_result.result_to_option
   )
 
-let on eventName decoder = onWithOptions eventName defaultOptions decoder
+let on ~(key:string) eventName decoder = onWithOptions ~key:key eventName defaultOptions decoder
 
 let targetValue = Tea_json.Decoder.at ["target"; "value"] Tea_json.Decoder.string
 

--- a/src-reason/tea_html.re
+++ b/src-reason/tea_html.re
@@ -440,8 +440,7 @@ type options = {
 
 let defaultOptions = {stopPropagation: false, preventDefault: false};
 
-let onWithOptions =
-    (~key: string, eventName, options: Tea_html.options, decoder) =>
+let onWithOptions = (~key: string, eventName, options: options, decoder) =>
   onCB(
     eventName,
     key,
@@ -458,8 +457,8 @@ let onWithOptions =
     },
   );
 
-let on = (eventName, decoder) =>
-  onWithOptions(eventName, defaultOptions, decoder);
+let on = (~key: string, eventName, decoder) =>
+  onWithOptions(~key, eventName, defaultOptions, decoder);
 
 let targetValue =
   Tea_json.Decoder.at(["target", "value"], Tea_json.Decoder.string);

--- a/test-ocaml/test_client_on_with_options.ml
+++ b/test-ocaml/test_client_on_with_options.ml
@@ -20,14 +20,14 @@ let view model =
   div [] (List.map (fun e -> div [] [e]) [
     model |> string_of_int |> text;
     button [onClick Click] [text "onClick"];
-    button [on "click" (Decoder.succeed Click)] [text "on \"click\""];
+    button [on ~key:"" "click" (Decoder.succeed Click)] [text "on \"click\""];
     a [href "https://www.google.com"] [text "a normal link"];
     a [
       href "https://www.google.com";
-      onWithOptions "click" { defaultOptions with preventDefault = true } (Tea.Json.Decoder.succeed Click);
+      onWithOptions ~key:"" "click" { defaultOptions with preventDefault = true } (Tea.Json.Decoder.succeed Click);
     ] [text "a link with prevent default"];
-    button [on "click" (Decoder.map set_value clientX)] [text "on \"click\", use clientX value"];
-    input' [type' "text"; on "input" (Decoder.map (fun v -> v |> int_of_string |> set_value) targetValue)] [];
+    button [on ~key:"" "click" (Decoder.map set_value clientX)] [text "on \"click\", use clientX value"];
+    input' [type' "text"; on ~key:"" "input" (Decoder.map (fun v -> v |> int_of_string |> set_value) targetValue)] [];
   ])
 
 

--- a/test-reason/test_client_on_with_options.re
+++ b/test-reason/test_client_on_with_options.re
@@ -24,7 +24,7 @@ let view = model => {
         model |> string_of_int |> text,
         button([onClick(Click)], [text("onClick")]),
         button(
-          [on("click", Decoder.succeed(Click))],
+          [on(~key="", "click", Decoder.succeed(Click))],
           [text("on \"click\"")],
         ),
         a([href("https://www.google.com")], [text("a normal link")]),
@@ -32,6 +32,7 @@ let view = model => {
           [
             href("https://www.google.com"),
             onWithOptions(
+              ~key="",
               "click",
               {...defaultOptions, preventDefault: true},
               Tea.Json.Decoder.succeed(Click),
@@ -40,13 +41,14 @@ let view = model => {
           [text("a link with prevent default")],
         ),
         button(
-          [on("click", Decoder.map(set_value, clientX))],
+          [on(~key="", "click", Decoder.map(set_value, clientX))],
           [text("on \"click\", use clientX value")],
         ),
         input'(
           [
             type'("text"),
             on(
+              ~key="",
               "input",
               Decoder.map(v => v |> int_of_string |> set_value, targetValue),
             ),


### PR DESCRIPTION
Fixes issues introduced by #105, which broke the build due for a couple of reasons:

1) self-referenced `Tea_html.options` instead of `options` in the type annotation for onWithOptions
2) Tea_html.on didn't require a key, which meant you got a curried thunk awaiting a `~key` parameter. This didn't require explicitly making `key` a parameter of `on`, but did so for readability.
3) Tests didn't compile due to missing `key`s.

Apologies for the churn here! I'm going to follow-up with an issue to suggest some tooling improvements we could add to make sure we don't submit regressions :)