### PR TITLE
Add http toTask

### DIFF
--- a/test-ocaml/index.html
+++ b/test-ocaml/index.html
@@ -18,6 +18,7 @@
     <button onclick="loadApp('attribute_removal')">Attribute Removal</button>
     <button onclick="loadApp('drag')">Drag</button>
     <button onclick="loadApp('on_with_options')">On (with options)</button>
+		<button onclick="loadApp('http_task')">Http task chaining</button>
   </div>
   <br />
   <div id="content" style="width:49%;display:inline-block;vertical-align:top;">

--- a/test-ocaml/test_client.ml
+++ b/test-ocaml/test_client.ml
@@ -6,3 +6,4 @@ let btn_update_span = let open Test_client_btn_update_span in main
 let attribute_removal = let open Test_client_attribute_removal in main
 let drag = let open Test_client_drag in main
 let on_with_options = let open Test_client_on_with_options in main
+let http_task = let open Test_client_http_task in main

--- a/test-ocaml/test_client_http_task.ml
+++ b/test-ocaml/test_client_http_task.ml
@@ -1,0 +1,39 @@
+open Tea
+open Tea.Html
+type ('ok,'err) result = ('ok,'err) Tea_result.t
+
+type msg =
+  | GotResponse of (string, string) result
+  | Req
+  [@@bs.deriving accessors]
+
+let update model = function
+  | GotResponse (Ok t) -> t, Cmd.none
+  | GotResponse (Error t) -> t, Cmd.none
+  | Req -> model,
+    Http.getString "https://jsonplaceholder.typicode.com/todos/1" |> Http.toTask |> Task.mapError Http.string_of_error
+    |> Task.andThen (fun res -> Ex.LocalStorage.setItem "todo-1" res)
+    |> Task.andThen (fun () -> Http.getString "https://jsonplaceholder.typicode.com/todos/2" |> Http.toTask |> Task.mapError Http.string_of_error)
+    |> Task.andThen (fun res -> Ex.LocalStorage.setItem "todo-2" res)
+    |> Task.andThen (fun () -> Task.succeed "both saved")
+    |> Task.attempt gotResponse
+
+
+let view model =
+  div [] [
+    button [onClick Req] [text "execute"];
+    text model;
+  ]
+
+let som = function
+  | GotResponse (Ok _) -> "GotResponse Ok"
+  | GotResponse (Error _) -> "GotResponse Error"
+  | Req -> "Req"
+
+let main =
+  Tea.Debug.standardProgram {
+    init = (fun () -> "nothing", Cmd.none);
+    subscriptions = (fun _ -> Sub.none);
+    update;
+    view;
+  } som

--- a/test-reason/test_client.re
+++ b/test-reason/test_client.re
@@ -1,15 +1,9 @@
 let counter = Test_client_counter.(main);
-
 let counter_debug_beginner = Test_client_counter_debug_beginner.(main);
-
 let counter_debug_standard = Test_client_counter_debug_standard.(main);
-
 let counter_debug_program = Test_client_counter_debug_program.(main);
-
 let btn_update_span = Test_client_btn_update_span.(main);
-
 let attribute_removal = Test_client_attribute_removal.(main);
-
 let drag = Test_client_drag.(main);
-
 let on_with_options = Test_client_on_with_options.(main);
+let http_task = Test_client_http_task.(main);

--- a/test-reason/test_client_http_task.re
+++ b/test-reason/test_client_http_task.re
@@ -1,0 +1,48 @@
+open Tea;
+open Tea.Html;
+type result('ok, 'err) = Tea_result.t('ok, 'err);
+
+[@bs.deriving accessors]
+type msg =
+  | GotResponse(result(string, string))
+  | Req;
+
+let update = model =>
+  fun
+  | GotResponse(Ok(t)) => (t, Cmd.none)
+  | GotResponse(Error(t)) => (t, Cmd.none)
+  | Req => (
+      model,
+      Http.getString("https://jsonplaceholder.typicode.com/todos/1")
+      |> Http.toTask
+      |> Task.mapError(Http.string_of_error)
+      |> Task.andThen(res => Ex.LocalStorage.setItem("todo-1", res))
+      |> Task.andThen(() =>
+           Http.getString("https://jsonplaceholder.typicode.com/todos/2")
+           |> Http.toTask
+           |> Task.mapError(Http.string_of_error)
+         )
+      |> Task.andThen(res => Ex.LocalStorage.setItem("todo-2", res))
+      |> Task.andThen(() => Task.succeed("both saved"))
+      |> Task.attempt(gotResponse),
+    );
+
+let view = model =>
+  div([], [button([onClick(Req)], [text("execute")]), text(model)]);
+
+let som =
+  fun
+  | GotResponse(Ok(_)) => "GotResponse Ok"
+  | GotResponse(Error(_)) => "GotResponse Error"
+  | Req => "Req";
+
+let main =
+  Tea.Debug.standardProgram(
+    {
+      init: () => ("nothing", Cmd.none),
+      subscriptions: _ => Sub.none,
+      update,
+      view,
+    },
+    som,
+  );


### PR DESCRIPTION
For now just a slightly modified copy of send to get the API in place.

Maybe it is time to revisit the idea of versioning different modules, either like we did with `Html2` in this repo, or, follow the elm way and keep the non-core modules in separate repos in order to support different release cadences (if needed)?